### PR TITLE
fix(request_types): rename limitprob to limitProb to match Manifold API (#18)

### DIFF
--- a/achaekek/request_types.py
+++ b/achaekek/request_types.py
@@ -116,14 +116,14 @@ class CreateBetRequest(RequestModel):
     amount: int
     contractId: str
     outcome: Literal["YES", "NO"] = field(default="YES")
-    limitprob: float | None = None
+    limitProb: float | None = None
     expiresAt: datetime | None = None
     answerId: str | None = None
 
     def to_json(self):
         json = super().to_json()
-        if "limitprob" in json:
-            json["limitprob"] = round(json["limitprob"], 2)
+        if "limitProb" in json:
+            json["limitProb"] = round(json["limitProb"], 2)
         if "expiresAt" in json:
             json["expiresAt"] = int(self.expiresAt.timestamp() * 1000)
         return json

--- a/tests/test_request_types.py
+++ b/tests/test_request_types.py
@@ -163,14 +163,17 @@ def test_create_bet_request_minimal():
     assert j["amount"] == 100
     assert j["contractId"] == "abc123"
     assert j["outcome"] == "YES"
-    assert "limitprob" not in j
+    assert "limitProb" not in j
     assert "expiresAt" not in j
 
 
 def test_create_bet_request_limitprob_rounding():
-    r = CreateBetRequest(amount=10, contractId="c1", limitprob=0.12345)
+    r = CreateBetRequest(amount=10, contractId="c1", limitProb=0.12345)
     j = r.to_json()
-    assert j["limitprob"] == 0.12
+    assert j["limitProb"] == 0.12
+    # The Manifold API rejects the lowercase `limitprob` key with 400; make
+    # sure we never accidentally serialise it under the old name again.
+    assert "limitprob" not in j
 
 
 def test_create_bet_request_expires_at():


### PR DESCRIPTION
## Summary

Fixes #18. ``CreateBetRequest`` declared the field as ``limitprob`` (all-lowercase), so the request payload included ``\"limitprob\": 0.12`` which Manifold's API rejects with:

```
{\"message\":\"Error validating request.\",\"details\":[{\"field\":null,\"error\":\"Unrecognized key(s) in object: 'limitprob'\"}]}
```

The companion ``CreateMultipleBetRequest`` (line 454) already used the correct ``limitProb``, only ``CreateBetRequest`` was misnamed. Renamed the dataclass field, the ``to_json`` round-trip key, and the existing tests; added a guard assertion that the old key never re-appears in the serialized JSON.

## Test plan

- [x] ``pytest tests/test_request_types.py``, 77 passed
- [x] Updated tests cover the rename and add a regression assertion (``\"limitprob\" not in j``) so a future re-introduction would fail the test